### PR TITLE
generate and add additional targets after processing all standard targets

### DIFF
--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -9,6 +9,7 @@ extends 'Pod::Simple::XHTML';
 with qw(
   Pod::Simple::Role::XHTML::WithLinkMappings
   Pod::Simple::Role::XHTML::WithAccurateTargets
+  Pod::Simple::Role::XHTML::WithExtraTargets
   Pod::Simple::Role::XHTML::WithErrata
   Pod::Simple::Role::XHTML::WithHighlightConfig
   Pod::Simple::Role::StripVerbatimIndent

--- a/lib/Pod/Simple/Role/XHTML/WithAccurateTargets.pm
+++ b/lib/Pod/Simple/Role/XHTML/WithAccurateTargets.pm
@@ -19,39 +19,13 @@ sub resolve_pod_page_link {
     return $prefix . $module . $postfix . $section;
 }
 
-around _end_head => sub {
-  my $orig = shift;
+after _end_head => sub {
   my $self = shift;
-  my $head_name = $self->{htext};
-  $self->{more_ids} = [ $self->id_extras($head_name) ];
-  $self->$orig(@_);
+  # the index entry added by default has the id of the link target, and uses
+  # it directly as a URL fragment. we need to re-encode it to a proper form.
   my $index_entry = $self->{'to_index'}[-1];
   $index_entry->[1] = encode_entities(
     url_encode_utf8( decode_entities( $index_entry->[1] ) ) );
-  return;
-};
-
-around end_item_text => sub {
-  my $orig = shift;
-  my $self = shift;
-  if ( $self->{anchor_items} ) {
-    my $item_name = $self->{'scratch'};
-    $self->{more_ids} = [ $self->id_extras($item_name) ];
-  }
-  $self->$orig(@_);
-};
-
-around emit => sub {
-  my $orig = shift;
-  my $self = shift;
-  my $ids  = delete $self->{more_ids};
-  if ( $ids && @$ids ) {
-    my $scratch = $self->{scratch};
-    my $add = join '', map qq{<a id="$_"></a>}, @$ids;
-    $scratch =~ s/(<\w[^>]*>)/$1$add/;
-    $self->{scratch} = $scratch;
-  }
-  $self->$orig(@_);
 };
 
 sub idify {
@@ -72,40 +46,6 @@ sub idify {
   encode_entities("$t$i");
 }
 
-sub id_extras {
-  my ( $self, $t ) = @_;
-
-  $t =~ s/<[^>]+>//g;
-  $t = decode_entities($t);
-  $t =~ s/^\s+//;
-  $t =~ s/\s+$//;
-  $t =~ s/[\s-]+/-/g;
-
-  # $full will be our preferred linking style, without much filtering
-  # $first will be the first word, often a method/function name
-  # $old will be a heavily filtered form for backwards compatibility
-
-  my $full = $t;
-  my ($first) = $t =~ /^(\w+)/;
-  $t =~ s/^[^a-zA-Z]+//;
-  $t =~ s/^$/pod/;
-  $t =~ s/[^-a-zA-Z0-9_:.]+/-/g;
-  $t =~ s/[-:.]+$//;
-  my $old = $t;
-  my %s   = ( $full => 1 );
-  my $ids = $self->{ids};
-  return
-    map encode_entities($_),
-    map {
-      my $i = '';
-      $i++ while $ids->{"$_$i"}++;
-      "$_$i";
-    }
-    grep !$s{$_}++,
-    grep defined,
-    ( $first, $old );
-}
-
 1;
 __END__
 
@@ -124,18 +64,10 @@ Pod::Simple::Role::XHTML::WithAccurateTargets - Use more accurate link targets
 
 =head1 DESCRIPTION
 
-Adds multiple link targets to rendered headings to allow more useful linking.
-
 The normal targets used by L<Pod::Simple::XHTML> are heavily filtered, meaning
 heading that are primarily symbolic (such as C<@_> in L<perlvar>) can't be
 usefully linked externally.  Link targets will be added using minimal filtering,
 which will also be used for linking to external pages.
-
-Many headings for functions and methods include the function signature.  This
-makes linking to the headings awkward.  Link targets based on the first word
-of headings will be added to make linking easier.  This form of linking is
-very common when linking to sections of L<perlfunc>, allowing links like
-C<< LE<lt>perlfunc/openE<gt> >>.
 
 =head1 SUPPORT
 

--- a/lib/Pod/Simple/Role/XHTML/WithExtraTargets.pm
+++ b/lib/Pod/Simple/Role/XHTML/WithExtraTargets.pm
@@ -1,0 +1,112 @@
+package Pod::Simple::Role::XHTML::WithExtraTargets;
+use HTML::Entities qw(decode_entities encode_entities);
+use URL::Encode qw(url_encode_utf8);
+use Moo::Role;
+use namespace::clean;
+
+our $VERSION = '0.002001';
+$VERSION =~ tr/_//d;
+
+before _end_head => sub {
+  my $self = shift;
+  my $head_name = $self->{htext};
+  $self->{more_ids} = [ $self->id_extras($head_name) ];
+};
+
+before end_item_text => sub {
+  my $self = shift;
+  if ( $self->{anchor_items} ) {
+    my $item_name = $self->{'scratch'};
+    $self->{more_ids} = [ $self->id_extras($item_name) ];
+  }
+};
+
+around emit => sub {
+  my $orig = shift;
+  my $self = shift;
+  my $ids  = delete $self->{more_ids};
+  if ( $ids && @$ids ) {
+    my $scratch = $self->{scratch};
+    my $add = join '', map qq{<a id="$_"></a>}, @$ids;
+    $scratch =~ s/(<\w[^>]*>)/$1$add/;
+    $self->{scratch} = $scratch;
+  }
+  $self->$orig(@_);
+};
+
+sub id_extras {
+  my ( $self, $t ) = @_;
+
+  $t =~ s/<[^>]+>//g;
+  $t = decode_entities($t);
+  $t =~ s/^\s+//;
+  $t =~ s/\s+$//;
+  $t =~ s/[\s-]+/-/g;
+
+  # $full will be our preferred linking style, without much filtering
+  # $first will be the first word, often a method/function name
+  # $old will be a heavily filtered form for backwards compatibility
+
+  my $full = $t;
+  my ($first) = $t =~ /^(\w+)/;
+  $t =~ s/^[^a-zA-Z]+//;
+  $t =~ s/^$/pod/;
+  $t =~ s/[^-a-zA-Z0-9_:.]+/-/g;
+  $t =~ s/[-:.]+$//;
+  my $old = $t;
+  my %s   = ( $full => 1 );
+  my $ids = $self->{ids};
+  return
+    map encode_entities($_),
+    map {
+      my $i = '';
+      $i++ while $ids->{"$_$i"}++;
+      "$_$i";
+    }
+    grep !$s{$_}++,
+    grep defined,
+    ( $first, $old );
+}
+
+
+1;
+__END__
+
+=head1 NAME
+
+Pod::Simple::Role::XHTML::WithExtraTargets - Add additional useful link targets
+
+=head1 SYNOPSIS
+
+  package MyPodParser;
+  with 'Pod::Simple::Role::XHTML::WithAccurateTargets';
+
+  my $parser = MyPodParser->new;
+  $parser->output_string(\my $html);
+  $parser->parse_string_document($pod);
+
+=head1 DESCRIPTION
+
+Adds multiple link targets to rendered headings to allow more useful linking.
+
+Many headings for functions and methods include the function signature.  This
+makes linking to the headings awkward.  Link targets based on the first word
+of headings will be added to make linking easier.  This form of linking is
+very common when linking to sections of L<perlfunc>, allowing links like
+C<< LE<lt>perlfunc/openE<gt> >>.
+
+Also adds link targets compatible with standard L<Pod::Simple::XHTML>.
+
+=head1 SUPPORT
+
+See L<MetaCPAN::Pod::XHTML> for support and contact information.
+
+=head1 AUTHORS
+
+See L<MetaCPAN::Pod::XHTML> for authors.
+
+=head1 COPYRIGHT AND LICENSE
+
+See L<MetaCPAN::Pod::XHTML> for the copyright and license.
+
+=cut

--- a/lib/Pod/Simple/Role/XHTML/WithPostProcess.pm
+++ b/lib/Pod/Simple/Role/XHTML/WithPostProcess.pm
@@ -1,0 +1,119 @@
+package Pod::Simple::Role::XHTML::WithPostProcess;
+use Moo::Role;
+use namespace::clean;
+
+our $VERSION = '0.002001';
+$VERSION =~ tr/_//d;
+
+around new => sub {
+  my $orig = shift;
+  my $class = shift;
+  my $self = $class->$orig(@_);
+  open my $fh, '>', \($self->{__buffer} = '') or die;
+  $self->{__real_output_fh} = $self->{output_fh};
+  $self->{output_fh} = $fh;
+  return $self;
+};
+
+around output_fh => sub {
+  my $orig = shift;
+  my $self = shift;
+  if (@_) {
+    $self->{__real_output_fh} = $_[0];
+  }
+  else {
+    return $self->{__real_output_fh};
+  }
+};
+
+around output_string => sub {
+  my $orig = shift;
+  my $self = shift;
+  return $self->$orig(@_)
+    if !@_;
+
+  local $self->{output_fh} = $self->{__real_output_fh};
+  my $output = $self->$orig(@_);
+  $self->{__real_output_fh} = $self->{output_fh};
+  return $output;
+};
+
+sub pre_process {
+  my ($self, $content) = @_;
+  return $content;
+}
+
+sub post_process {
+  my ($self, $output) = @_;
+  return $output;
+}
+
+after end_Document => sub {
+  my ($self) = @_;
+  my $full_content = $self->{__buffer};
+  $self->{__buffer} = '';
+  print { $self->{__real_output_fh} } $self->post_process($full_content);
+};
+
+before emit => sub {
+  my $self = shift;
+  $self->{scratch} = $self->pre_process($self->{scratch});
+};
+
+1;
+__END__
+
+=head1 NAME
+
+Pod::Simple::Role::XHTML::WithPostProcess - Post process entire output from XHTML conversion
+
+=head1 SYNOPSIS
+
+  package MyPodParser;
+  with 'Pod::Simple::Role::XHTML::WithPostProcess';
+
+  around post_process => sub {
+    my ($self, $content) = @_;
+    $content =~ s/Foo/Bar/g;
+    return $content;
+  };
+
+  my $parser = MyPodParser->new;
+  $parser->output_string(\my $html);
+  $parser->parse_string_document($pod);
+
+=head1 DESCRIPTION
+
+Allows post-processing of entire converted Pod document before outputting. This
+role is meant to be used by other roles that need to do post processing on the
+full document that is output, rather than as the content is generated. On its
+own, this role will not have any impact on the content of the output.
+
+=head1 METHODS
+
+Two methods are provided which should be modified to make use of this role.
+
+=head2 pre_process ( $new_content )
+
+Called when initially adding content to the document. C<$new_content> is the
+content being added to the output document. Expected to return the content to
+be added to the output.
+
+=head2 post_process ( $full_content )
+
+Called just before outputting the final document. C<$full_content> is the full
+output. Expected to return the content to be output.
+
+=head1 SUPPORT
+
+See L<MetaCPAN::Pod::XHTML> for support and contact information.
+
+=head1 AUTHORS
+
+See L<MetaCPAN::Pod::XHTML> for authors.
+
+=head1 COPYRIGHT AND LICENSE
+
+See L<MetaCPAN::Pod::XHTML> for the copyright and license.
+
+=cut

--- a/t/extra-targets.t
+++ b/t/extra-targets.t
@@ -4,11 +4,12 @@ use Test::More;
 
 my $class;
 {
-  package ParserWithAccurateTargets;
+  package ParserWithExtraTargets;
   $class = __PACKAGE__;
   use Moo;
   extends 'Pod::Simple::XHTML';
   with 'Pod::Simple::Role::XHTML::WithAccurateTargets';
+  with 'Pod::Simple::Role::XHTML::WithExtraTargets';
 }
 
 my $parser = $class->new;
@@ -27,12 +28,19 @@ my $pod = <<'END_POD';
 
   =head2 $self->some_method( \%options );
 
+  =head2 options ( $options )
+
+  =head1 options
+
+  There are options.
+
   =cut
 END_POD
 $pod =~ s/^  //mg;
 $parser->parse_string_document($pod);
 
 like $output, qr/Pod::Document/;
-like $output, qr/<h2 id="\$self-&gt;some_method\(-\\%options-\);">/;
+like $output, qr/<a id="self--some_method---options">/;
+like $output, qr/<a id="options"><\/a><a id="options----options">/;
 
 done_testing;

--- a/t/extra-targets.t
+++ b/t/extra-targets.t
@@ -41,6 +41,7 @@ $parser->parse_string_document($pod);
 
 like $output, qr/Pod::Document/;
 like $output, qr/<a id="self--some_method---options">/;
-like $output, qr/<a id="options"><\/a><a id="options----options">/;
+like $output, qr/<h1 id="options">/;
+like $output, qr/<a id="options1"><\/a><a id="options----options">/;
 
 done_testing;


### PR DESCRIPTION
We generate extra link targets both for backwards compatibility, as well
as for the first word to make linking to functions easier in many cases.
Previously, these targets were added as the document was being
processed. But the first word of a heading can easily conflict with a
later heading that should take priority. This means the extra targets
need to be added only after the entire document has been processed.

Add a new role that buffers the entire output and allows filtering it.
Also provide a method that is called whenever new output added. This
allows the code adding the extra targets to collect all of the
information needed to add the targets as the document is processed, and
then when finished inject the new targets.